### PR TITLE
displays color swatch or button select based on product variant

### DIFF
--- a/src/components/product/product-description.tsx
+++ b/src/components/product/product-description.tsx
@@ -8,11 +8,12 @@ import { Prose } from '@/components/prose';
 import type { Product } from '@/types/shopify-types';
 
 export function ProductDescription({ product }: { product: Product }) {
+  console.log('product', product);
   return (
     <>
       <div className="mb-6 flex flex-col border-b pb-6 dark:border-neutral-700">
         <h1 className="mb-2 text-5xl font-medium">{product.title}</h1>
-        <Badge className="mr-auto bg-blue-700" size="lg">
+        <Badge className="mr-auto bg-blue-700 dark:bg-primary" size="lg">
           <Price
             amount={product.priceRange.maxVariantPrice.amount}
             currencyCode={product.priceRange.maxVariantPrice.currencyCode}

--- a/src/components/product/variant-selector.tsx
+++ b/src/components/product/variant-selector.tsx
@@ -5,11 +5,12 @@ import { cn } from '@/lib/utils';
 import { useProduct, useUpdateURL } from '@/providers/product-provider';
 
 import { Button } from '@/components/ui/button';
-import { VariantSwatch } from './variant-swatch';
+
+import { COLOR_MAP , VariantSwatch } from '@/components/product/variant-swatch';
 
 import type { ProductOption, ProductVariant } from '@/types/shopify-types';
 
-import { COLOR_MAP } from '@/components/product/variant-swatch';
+
 
 type Combination = {
   id: string;

--- a/src/components/product/variant-selector.tsx
+++ b/src/components/product/variant-selector.tsx
@@ -5,12 +5,16 @@ import { cn } from '@/lib/utils';
 import { useProduct, useUpdateURL } from '@/providers/product-provider';
 
 import { Button } from '@/components/ui/button';
+import { VariantSwatch } from './variant-swatch';
 
 import type { ProductOption, ProductVariant } from '@/types/shopify-types';
+
+import { COLOR_MAP } from '@/components/product/variant-swatch';
 
 type Combination = {
   id: string;
   availableForSale: boolean;
+  color: string;
   [key: string]: string | boolean;
 };
 
@@ -31,68 +35,95 @@ export function VariantSelector({
   }
 
   const combinations: Combination[] = variants.map((variant) => ({
-    id: variant.id,
-    availableForSale: variant.availableForSale,
     ...variant.selectedOptions.reduce(
       (accumulator, option) => ({ ...accumulator, [option.name.toLowerCase()]: option.value }),
       {}
-    )
+    ),
+    id: variant.id,
+    availableForSale: variant.availableForSale,
+    color: variant.title
   }));
 
-  return options.map((option) => (
-    <form key={option.id}>
-      <dl className="mb-8">
-        <dt className="mb-4 text-sm uppercase tracking-wide">{option.name}</dt>
-        <dd className="flex flex-wrap gap-3">
-          {option.values.map((value) => {
-            const optionNameLowerCase = option.name.toLowerCase();
+  const isColorOption = (color: string | undefined) => {
+    return color ? COLOR_MAP[color as keyof typeof COLOR_MAP] : undefined;
+  };
 
-            // Base option params on current selectedOptions so we can preserve any other param state.
-            const optionParams = { ...state, [optionNameLowerCase]: value };
+  return options.map((option) => {
+    const swatches: React.ReactNode[] = [];
+    const buttons: React.ReactNode[] = [];
 
-            // Filter out invalid options and check if the option combination is available for sale.
-            const filtered = Object.entries(optionParams).filter(([key, value]) =>
-              options.find(
-                (option) => option.name.toLowerCase() === key && option.values.includes(value)
-              )
-            );
-            const isAvailableForSale = combinations.find((combination) =>
-              filtered.every(
-                ([key, value]) => combination[key] === value && combination.availableForSale
-              )
-            );
+    option.values.forEach((value) => {
+      const optionNameLowerCase = option.name.toLowerCase();
 
-            // The option is active if it's in the selected options.
-            const isActive = state[optionNameLowerCase] === value;
+      // Base option params on current selectedOptions so we can preserve any other param state.
+      const optionParams = { ...state, [optionNameLowerCase]: value };
 
-            return (
-              //TODO: check these classes in relation to the shadcn button
-              <Button
-                formAction={() => {
-                  const newState = updateOption(optionNameLowerCase, value);
-                  updateURL(newState);
-                }}
-                key={value}
-                aria-disabled={!isAvailableForSale}
-                disabled={!isAvailableForSale}
-                title={`${option.name} ${value}${!isAvailableForSale ? ' (Out of Stock)' : ''}`}
-                className={cn(
-                  'flex min-w-[48px] items-center justify-center rounded-full border bg-neutral-100 px-2 py-1 text-sm dark:border-neutral-800 dark:bg-neutral-900',
-                  {
-                    'cursor-default ring-2 ring-blue-600': isActive,
-                    'ring-1 ring-transparent transition duration-300 ease-in-out hover:ring-blue-600':
-                      !isActive && isAvailableForSale,
-                    'relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-500 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform dark:bg-neutral-900 dark:text-neutral-400 dark:ring-neutral-700 before:dark:bg-neutral-700':
-                      !isAvailableForSale
-                  }
-                )}
-              >
-                {value}
-              </Button>
-            );
-          })}
-        </dd>
-      </dl>
-    </form>
-  ));
+      // Filter out invalid options and check if the option combination is available for sale.
+      const filtered = Object.entries(optionParams).filter(([key, value]) =>
+        options.find((option) => option.name.toLowerCase() === key && option.values.includes(value))
+      );
+      const isAvailableForSale = combinations.find((combination) =>
+        filtered.every(([key, value]) => combination[key] === value && combination.availableForSale)
+      );
+
+      const variant = combinations.find((combination) =>
+        filtered.every(([key, value]) => combination[key] === value)
+      );
+      const variantColor = variant?.color?.toLowerCase();
+
+      // The option is active if it's in the selected options.
+      const isActive = state[optionNameLowerCase] === value;
+
+      const handleOptionChange = () => {
+        const newState = updateOption(optionNameLowerCase, value);
+        updateURL(newState);
+      };
+
+      if (isColorOption(variantColor)) {
+        swatches.push(
+          <VariantSwatch
+            key={value}
+            value={value}
+            isActive={isActive}
+            isAvailableForSale={!!isAvailableForSale}
+            optionName={option.name}
+            onClickAction={handleOptionChange}
+          />
+        );
+      } else {
+        buttons.push(
+          <Button
+            key={value}
+            formAction={handleOptionChange}
+            aria-disabled={!isAvailableForSale}
+            disabled={!isAvailableForSale}
+            title={`${option.name} ${value}${!isAvailableForSale ? ' (Out of Stock)' : ''}`}
+            variant="outline"
+            className={cn({
+              'cursor-default bg-blue-600 text-background hover:bg-blue-600 hover:text-background dark:bg-primary dark:text-foreground':
+                isActive,
+              'transition duration-100 ease-in-out hover:bg-gray-200 dark:hover:bg-gray-800':
+                !isActive && isAvailableForSale,
+              'relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-500 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform hover:bg-neutral-100 hover:text-neutral-500 dark:bg-neutral-900 dark:text-neutral-400 dark:ring-neutral-700 before:dark:bg-neutral-700 dark:hover:bg-neutral-900 dark:hover:text-neutral-400':
+                !isAvailableForSale
+            })}
+          >
+            {value}
+          </Button>
+        );
+      }
+    });
+
+    return (
+      <form key={option.id}>
+        <dl className="mb-8">
+          <dt className="mb-4 text-sm uppercase tracking-wide">{option.name}</dt>
+          <dd className="flex flex-col gap-4">
+            {swatches.length > 0 && <div className="flex flex-wrap gap-3">{swatches}</div>}
+            {buttons.length > 0 && <div className="flex flex-wrap gap-3">{buttons}</div>}
+          </dd>
+        </dl>
+      </form>
+    );
+  });
 }

--- a/src/components/product/variant-swatch.tsx
+++ b/src/components/product/variant-swatch.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+import { Button } from '@/components/ui/button';
+
+interface VariantSwatchProps {
+  value: string;
+  isActive: boolean;
+  isAvailableForSale: boolean;
+  optionName: string;
+  onClickAction: () => void;
+}
+
+export const COLOR_MAP: Record<string, string> = {
+  black: '#000000',
+  white: '#FFFFFF',
+  red: '#FF0000',
+  blue: '#0000FF',
+  green: '#008000',
+  yellow: '#FFFF00',
+  purple: '#800080',
+  pink: '#FFC0CB',
+  gray: '#808080',
+  brown: '#A52A2A'
+  // Add more color mappings as needed
+};
+
+export function VariantSwatch({
+  value,
+  isActive,
+  isAvailableForSale,
+  optionName,
+  onClickAction
+}: VariantSwatchProps) {
+  const colorValue = COLOR_MAP[value.toLowerCase()] || value;
+
+  return (
+    <Button
+      formAction={onClickAction}
+      disabled={!isAvailableForSale}
+      title={`${optionName} ${value}${!isAvailableForSale ? ' (Out of Stock)' : ''}`}
+      variant="outline"
+      className={cn('h-8 w-8 rounded-full p-0', {
+        'cursor-default ring-2 ring-blue-600': isActive,
+        'hover:ring-2 hover:ring-blue-600': !isActive && isAvailableForSale,
+        'cursor-not-allowed opacity-50': !isAvailableForSale
+      })}
+    >
+      <span
+        className={cn('block h-6 w-6 rounded-full border', {
+          'border-neutral-300 dark:border-neutral-700': !isActive
+        })}
+        style={{ backgroundColor: colorValue }}
+      />
+      <span className="sr-only">{value}</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
# Color Swatch Implementation for Product Variants

## Changes
- Added color swatch component for variant selection when the option is a color
- Separated variant selection UI into distinct color swatches and regular buttons
- Implemented a color mapping system for consistent color representation
- Improved layout organization with vertical stacking of different option types

## Implementation Details
- Created `VariantSwatch` component for color-specific variant selection
- Added `COLOR_MAP` to maintain consistent color hex values
- Modified [VariantSelector](cci:1://file:///Users/seth/apps/clients-2024/matic/matic-commerce/src/components/product/variant-selector.tsx:20:0-130:1) to:
  - Detect color options using the `COLOR_MAP`
  - Group swatches and buttons separately in the UI
  - Maintain existing functionality for non-color variants
- Improved code organization and readability with better component structure

## Visual Changes
- Color options now display as circular swatches with proper active/hover states
- Non-color options remain as traditional buttons
- Options are now organized vertically with color swatches and regular buttons on separate lines

## Testing
- Verify color swatches display correctly for color variants
- Confirm non-color variants still work as expected with button UI
- Check active states and hover interactions for both swatch and button variants
- Ensure proper handling of out-of-stock variants in both display types

Closes #3 